### PR TITLE
fix:删除无用参数singleIndex

### DIFF
--- a/docs/components/picker.md
+++ b/docs/components/picker.md
@@ -214,7 +214,6 @@
 | confirmText		| 确认按钮的文字								| String				| 确认		| -			|
 | cancelColor		| 取消按钮的颜色								| String				| #909193	| -			|
 | confirmColor		| 确认按钮的颜色								| String				| #3c9cff	| -			|
-| singleIndex		| 选择器只有一列时，默认选中项的索引，从0开始    	| Array             	| [0]		| -			|
 | visibleItemCount	| 每列中可见选项的数量						    | String &#124; Number	| 5			| -			|
 | keyName			| 自定义需要展示的`text`属性键名				| String				| text		| -			|
 | closeOnClickOverlay| 是否允许点击遮罩关闭选择器（注意：关闭事件需要自行处理，只会在开启closeOnClickOverlay后点击遮罩层执行close回调）					| Boolean				| false		| true		|


### PR DESCRIPTION
singleIndex在源码中没有任何引用，且已经提供defaultIndex作为各列的默认索引，单列选择器同样可以使用，所以singleIndex参数无实际用途。已在源码提交pr571删除对应部分。